### PR TITLE
[WIP] fix: ghq root を実際のリポジトリパスに修正

### DIFF
--- a/dotfiles/gitconfig
+++ b/dotfiles/gitconfig
@@ -57,7 +57,7 @@
   required = true
 
 [ghq]
-  root = ~/.go/src
+  root = ~/ghq
 
 [include]
   #最後に読み込んで.localの設定でoverwriteできるようにした


### PR DESCRIPTION
## やったこと
- ghq.root の設定を `~/.go/src` から `~/ghq` に修正
- これにより `ghq list` が正しくリポジトリを検出し、`Ctrl+]` での peco 選択が動作するようになった

## 確認したこと
- [ ] `ghq list` でリポジトリが表示されること
- [ ] `Ctrl+]` で peco によるリポジトリ選択ができること

🤖 Generated with [Claude Code](https://claude.com/claude-code)