### PR TITLE
docs: セットアップドキュメントを簡素化

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ cd macbook-provisioning
 export PATH=$PATH:/opt/homebrew/bin
 make setup
 make package/install
-cd dotfiles && make install && cd ..
-make restore
+make link
 ```
 
 ## 手動インストールが必要なアプリ

--- a/docs/fresh-setup.md
+++ b/docs/fresh-setup.md
@@ -1,51 +1,20 @@
 # 新規 Mac セットアップ手順
 
-クリーンインストール後、または新しい Mac を設定する際の手順です。
+クリーンインストール後、または新しい Mac を設定する際の手順。
 
-## 前提条件
+## 1. 事前準備
 
-- macOS のクリーンインストールが完了している
-- Apple ID でログイン済み
-- インターネットに接続している
+1. [1Password](https://1password.com/downloads/mac/) をインストールしてログイン
+2. SSH 鍵を復元（1Password から）または新規作成
 
-## 1. 最初に手動でインストールするアプリ
-
-### 1Password のインストール
-1. [1Password](https://1password.com/downloads/mac/) をダウンロードしてインストール
-2. アカウントにログイン
-3. SSH 鍵や各種認証情報にアクセスできることを確認
-
-### Chrome のインストール
-1. Safari で [Google Chrome](https://www.google.com/chrome/) をダウンロード
-2. インストールして既定のブラウザに設定
-
-## 2. SSH 鍵の設定
-
-### 1Password から SSH 鍵を復元する場合
-1. 1Password から SSH 秘密鍵をエクスポート
-2. `~/.ssh/` に配置して権限を設定：
 ```bash
-mkdir -p ~/.ssh
-chmod 700 ~/.ssh
-# 1Password から鍵をコピー後
-chmod 600 ~/.ssh/id_ed25519
-chmod 644 ~/.ssh/id_ed25519.pub
-```
-
-### 新規に SSH 鍵を作成する場合
-```bash
+# 新規作成の場合
 ssh-keygen -t ed25519 -C "your_email@example.com"
 cat ~/.ssh/id_ed25519.pub | pbcopy
-```
-GitHub > Settings > SSH and GPG keys で公開鍵を追加
-
-### SSH 接続テスト
-```bash
-ssh -T git@github.com
-# "Hi username!" と表示されれば成功
+# GitHub > Settings > SSH and GPG keys で追加
 ```
 
-## 3. リポジトリのクローン
+## 2. リポジトリのクローン
 
 ```bash
 mkdir -p ~/.go/src/github.com/chocopie116
@@ -54,144 +23,46 @@ git clone git@github.com:chocopie116/macbook-provisioning.git
 cd macbook-provisioning
 ```
 
-## 4. Homebrew セットアップ
+## 3. セットアップ実行
 
-### Xcode Command Line Tools と Homebrew のインストール
 ```bash
-xcode-select --install  # 必要に応じて
+# Homebrew インストール
+xcode-select --install
 make setup
 export PATH=$PATH:/opt/homebrew/bin
-```
 
-## 5. パッケージのインストール
-
-### 全パッケージをインストール
-```bash
+# パッケージインストール
 make package/install
+
+# 設定ファイルのリンク
+make link
+
+# macOS システム設定（オプション）
+bash macos/defaults.sh
 ```
 
-これにより以下がインストールされます：
-- CLI ツール（brew formulae）
-- GUI アプリケーション（brew casks）
-- Mac App Store アプリ（mas）
-- VSCode/Cursor 拡張
+## 4. 追加設定
 
-### npm パッケージのインストール
-```bash
-npm install -g aicommits
-```
-
-## 6. dotfiles の設定
-
-### シンボリックリンクの作成
-```bash
-cd dotfiles
-make install
-cd ..
-```
-
-これにより以下が設定されます：
-- `~/.zshrc`
-- `~/.vimrc`
-- `~/.gitconfig`
-- `~/.config/peco/config.json`
-
-### zplug プラグインのインストール
-新しいターミナルを開くと自動的にプラグインのインストールが促されます。
-
-## 7. アプリケーション設定の復元
-
-### Karabiner と Claude Code の設定
-```bash
-make restore
-```
-
-### Raycast の設定インポート
+### Raycast
 1. Raycast を開く（⌘ + Space）
-2. 「Import Settings & Data」と入力して実行
-3. 保存した `.rayconfig` ファイルを選択
-4. エクスポート時に設定したパスフレーズを入力
+2. 「Import Settings & Data」で `.rayconfig` ファイルをインポート
 
-### macOS システム設定
+### asdf ランタイム
 ```bash
-cd dotfiles
-bash .macos
-```
-
-> **Note**: 一部の設定は再起動後に有効になります。
-
-## 8. その他の設定
-
-### Git のローカル設定
-```bash
-# 必要に応じてローカル設定を作成
-vim ~/.gitconfig.local
-```
-
-### アプリケーションへのログイン
-- [ ] Dropbox
-- [ ] Slack
-- [ ] Discord
-- [ ] Notion
-- [ ] その他のアプリ
-
-### 手動インストールが必要なアプリ
-- [InYourFace](https://inyourface.app/) - カレンダー通知アプリ
-
-## 9. 確認作業
-
-### 動作確認
-- [ ] ターミナルで `peco` が動作するか
-- [ ] `ghq get` でリポジトリをクローンできるか
-- [ ] `git` のエイリアスが動作するか（`git s`, `git lg` など）
-- [ ] Karabiner のキーマッピングが動作するか
-- [ ] VSCode/Cursor で拡張が読み込まれているか
-
-### asdf でのランタイム設定
-```bash
-# Node.js
-asdf plugin add nodejs
-asdf install nodejs latest
-asdf global nodejs latest
-
-# その他必要な言語
-asdf plugin add python
-asdf plugin add ruby
-# ...
+asdf plugin add nodejs && asdf install nodejs latest && asdf global nodejs latest
 ```
 
 ## クイックリファレンス
 
 ```bash
-# 1Password と Chrome を手動インストール後
-# SSH 鍵を設定してから以下を実行
-
+# SSH 設定後に実行
 mkdir -p ~/.go/src/github.com/chocopie116
 cd ~/.go/src/github.com/chocopie116
 git clone git@github.com:chocopie116/macbook-provisioning.git
 cd macbook-provisioning
-
 xcode-select --install
 make setup
 export PATH=$PATH:/opt/homebrew/bin
 make package/install
-cd dotfiles && make install && cd ..
-make restore
-npm install -g aicommits
-```
-
-## トラブルシューティング
-
-### Homebrew のパスが通らない
-```bash
-eval "$(/opt/homebrew/bin/brew shellenv)"
-```
-
-### mas でアプリがインストールできない
-Mac App Store にログインしていることを確認してください。
-
-### zplug のエラー
-```bash
-source /opt/homebrew/opt/zplug/init.zsh
-zplug install
+make link
 ```

--- a/docs/pre-clean-install.md
+++ b/docs/pre-clean-install.md
@@ -1,99 +1,39 @@
 # クリーンインストール前の準備
 
-macOS をクリーンインストールする前に実施する手順です。年末の大掃除などで Mac をリフレッシュする際に参照してください。
+macOS をクリーンインストールする前に実施する手順。
 
-## 1. データのバックアップ
+## 1. バックアップ確認
 
-### 必須のバックアップ
-- [ ] iCloud Drive の同期が完了していることを確認
-- [ ] 1Password のバックアップ（クラウド同期確認）
+- [ ] iCloud Drive の同期完了
+- [ ] 1Password のクラウド同期確認
 - [ ] SSH 鍵のバックアップ（`~/.ssh/`）
-- [ ] GPG 鍵のバックアップ（使用している場合）
-- [ ] ローカルのみに存在する重要ファイルの確認
 
-### 確認すべき設定
-- [ ] Karabiner の設定が最新か確認（`templates/karabiner.json`）
-- [ ] VSCode/Cursor の拡張が Brewfile に反映されているか
-- [ ] dotfiles の変更がコミットされているか
+## 2. 設定の確認
 
-## 2. パッケージの精査
+- [ ] Karabiner の設定が最新か（`karabiner/karabiner.json`）
+- [ ] VSCode/Cursor 拡張が Brewfile に反映されているか
+- [ ] dotfiles の変更がコミット済みか
 
-### 現在のパッケージを確認
+## 3. パッケージの更新
+
 ```bash
-# 現在インストールされているパッケージを Brewfile に出力
+# 現在のパッケージを Brewfile に出力
 make package/dump
 
-# 差分を確認
+# 差分を確認してコミット
 git diff Brewfile
+git add -A && git commit -m "update packages" && git push
 ```
 
-### 不要パッケージの削除
-```bash
-# Brewfile にないパッケージを確認
-make package/check
+## 4. アプリ設定のエクスポート
 
-# 不要パッケージを削除
-make package/cleanup
-```
+### Raycast
+1. 「Export Settings & Data」で `.rayconfig` を iCloud Drive に保存
 
-### パッケージリストのレビュー
-Brewfile を開いて以下を確認：
-- [ ] 使っていないアプリはないか
-- [ ] 重複している機能のアプリはないか
-- [ ] VSCode/Cursor 拡張で不要なものはないか
+## 5. クリーンインストール
 
-## 3. 設定のエクスポート
-
-### このリポジトリを更新
-```bash
-cd ~/path/to/macbook-provisioning
-
-# Brewfile を更新
-make package/dump
-
-# 変更をコミット
-git add -A
-git commit -m "クリーンインストール前のパッケージ更新"
-git push
-```
-
-### アプリ固有の設定
-- [ ] BetterTouchTool の設定エクスポート
-- [ ] その他カスタマイズしたアプリの設定
-
-### Raycast の設定エクスポート
-1. Raycast を開く（⌘ + Space）
-2. 「Export Settings & Data」と入力して実行
-3. パスフレーズを設定（インポート時に必要）
-4. `.rayconfig` ファイルを iCloud Drive または安全な場所に保存
-
-## 4. アカウント情報の確認
-
-以下のサービスにログインできることを確認：
-- [ ] Apple ID
-- [ ] GitHub（SSH 鍵または認証アプリ）
-- [ ] 1Password
-- [ ] Dropbox
-- [ ] その他必要なサービス
-
-## 5. macOS のクリーンインストール
-
-### インストール方法
 1. Mac をシャットダウン
-2. 電源ボタンを長押しして起動オプションを表示（Apple Silicon Mac）
-3. 「オプション」を選択
-4. ディスクユーティリティで Macintosh HD を消去
-5. macOS を再インストール
+2. 電源ボタン長押しで起動オプション表示
+3. ディスクユーティリティで消去 → macOS 再インストール
 
-### 参考
-- [Mac を消去して工場出荷時の設定にリセットする - Apple サポート](https://support.apple.com/ja-jp/HT212749)
-
-## チェックリスト
-
-クリーンインストール前の最終確認：
-
-- [ ] このリポジトリが最新の状態で push されている
-- [ ] iCloud の同期が完了している
-- [ ] 重要なローカルファイルがバックアップされている
-- [ ] 各サービスへのログイン情報が確認できる
-- [ ] SSH 鍵がバックアップされている（または新規作成する準備ができている）
+参考: [Mac を消去して工場出荷時の設定にリセットする](https://support.apple.com/ja-jp/HT212749)


### PR DESCRIPTION
## 影響範囲
ドキュメントのみの変更。既存の機能やスクリプトへの影響なし。

## 変更概要
- README.md: `cd dotfiles && make install` を `make link` に修正（現在のMakefile構成に合わせる）
- fresh-setup.md: 冗長な説明や重複するコマンド例を削除し、必要最小限の手順に簡素化
- pre-clean-install.md: 詳細すぎるチェックリストを整理し、簡潔な手順に変更

## AIが確認したこと
- [x] 各ドキュメントのコマンドがMakefileのターゲットと整合していること
- [x] 重要な手順が削除されていないこと
- [x] マークダウンの構文が正しいこと

## 人間に確認してほしいこと
- [ ] 簡素化により削除した情報に、実際に必要なものがないか
- [ ] Raycast設定のエクスポート/インポート手順が十分か