### PR TITLE
Remove toggle-pane plugin from yazi config

### DIFF
--- a/yazi/keymap.toml
+++ b/yazi/keymap.toml
@@ -15,14 +15,3 @@ on   = [ "y", "p" ]
 run  = "shell 'printf \"%s\" $0 | pbcopy' --orphan"
 desc = "パスをクリップボードにコピー"
 
-# toggle-pane: プレビューペインの表示/非表示
-[[mgr.prepend_keymap]]
-on   = "T"
-run  = "plugin toggle-pane --args=min-preview"
-desc = "プレビューペインの表示/非表示"
-
-# toggle-pane: プレビューペインの最大化/復元
-[[mgr.prepend_keymap]]
-on   = "i"
-run  = "plugin toggle-pane --args=max-preview"
-desc = "プレビューペインの最大化/復元"

--- a/yazi/package.toml
+++ b/yazi/package.toml
@@ -13,10 +13,5 @@ use = "yazi-rs/plugins:smart-enter"
 rev = "68f7d48"
 hash = "56fdabc96fc1f4d53c96eb884b02a5be"
 
-[[plugin.deps]]
-use = "yazi-rs/plugins:toggle-pane"
-rev = "68f7d48"
-hash = "8a7c58225816a163a6e8730c0adafbc8"
-
 [flavor]
 deps = []


### PR DESCRIPTION
## 影響範囲
yaziのプレビューペイン折りたたみショートカット(T, i)が削除されます

## 変更概要
- yazi/package.tomlからtoggle-paneプラグイン削除
- yazi/keymap.tomlからtoggle-pane関連のキーマップ(T, i)削除

## AIが確認したこと
- [ ] toggle-paneプラグインがyazi 26.1.4で動作しない
- [ ] package.tomlから定義削除
- [ ] keymap.tomlからショートカット削除
- [ ] プラグインディレクトリから物理削除済み

## 人間に確認してほしいこと
- [ ] yaziでT/iキーが不要か確認
- [ ] デフォルトのペイン操作で問題ないか確認