### PR TITLE
feat: peco_srcにObsidian notebookを追加

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -110,9 +110,10 @@ function peco_select_history() {
 zle -N peco_select_history
 
 function peco_src() {
-    local src_dir=$(ghq list --full-path | peco --query "$LBUFFER")
+    # ghq listにnotebookを追加（iCloud上のObsidian vault）
+    local src_dir=$( (ghq list --full-path; echo "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/notebook") | peco --query "$LBUFFER")
     if [ -n "$src_dir" ]; then
-        BUFFER="cd $src_dir"
+        BUFFER="cd \"$src_dir\""
         zle accept-line
     fi
     zle -R -c


### PR DESCRIPTION
## 影響範囲
zshでCtrl+]（peco_src）を使ったディレクトリ移動時の選択肢

## 変更概要
- peco_srcでghq listの結果にiCloud上のObsidian notebookパスを追加
- スペースを含むパスに対応するためcdコマンドをダブルクォートで囲む

## AIが確認したこと
- [x] zshrcの構文エラーがないこと
- [x] スペースを含むパスが正しく処理されること

## 人間に確認してほしいこと
- [ ] source ~/.zshrc後、Ctrl+]でnotebookが表示されること
- [ ] notebookを選択してcdできること