### PR TITLE
feat: cccコマンドを追加（peco+ghq+claude起動）

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -120,6 +120,13 @@ function peco_src() {
 }
 zle -N peco_src
 
+function ccc() {
+    local src_dir=$( (ghq list --full-path; echo "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/notebook") | peco --query "$LBUFFER")
+    if [ -n "$src_dir" ]; then
+        cd "$src_dir" && claude --dangerously-skip-permissions
+    fi
+}
+
 # -------------------------------------
 # キーバインド
 # -------------------------------------


### PR DESCRIPTION
## 影響範囲
zshでcccコマンドが使えるようになる

## 変更概要
- pecoでghqリポジトリ（+Obsidian notebook）を選択してcdし、claude --dangerously-skip-permissionsを起動するcccコマンドを追加

## AIが確認したこと
- [x] 既存のpeco_src関数と同じパターンで実装
- [x] Notebookパスも選択肢に含まれている

## 人間に確認してほしいこと
- [ ] source ~/.zshrc後にcccコマンドが動作すること