### PR TITLE
feat: yaziを1パネル表示に変更

### DIFF
--- a/yazi/yazi.toml
+++ b/yazi/yazi.toml
@@ -2,6 +2,9 @@
 # https://yazi-rs.github.io/docs/configuration/yazi
 
 [mgr]
+# 1パネル表示（親:現在:プレビュー）
+ratio = [0, 1, 0]
+
 # Show hidden files (dotfiles) by default
 show_hidden = true
 


### PR DESCRIPTION
## 影響範囲
yaziのレイアウトが3カラムから1カラムに変更される

## 変更概要
- yazi.tomlに`ratio = [0, 1, 0]`を追加し、親ディレクトリとプレビューパネルを非表示に

## AIが確認したこと
- [x] yazi公式ドキュメントのratio設定仕様を確認
- [x] 既存設定との競合がないことを確認

## 人間に確認してほしいこと
- [ ] yaziを再起動して1パネル表示になっていることを確認
- [ ] 使い勝手が期待通りか確認