### PR TITLE
feat: AeroSpaceにモニター間移動ショートカットを追加

### DIFF
--- a/aerospace/aerospace.toml
+++ b/aerospace/aerospace.toml
@@ -38,6 +38,18 @@ alt-shift-7 = 'move-node-to-workspace 7'
 alt-shift-8 = 'move-node-to-workspace 8'
 alt-shift-9 = 'move-node-to-workspace 9'
 
+# モニター間フォーカス移動 (alt + 方向キー)
+alt-left = 'focus-monitor left'
+alt-right = 'focus-monitor right'
+alt-up = 'focus-monitor up'
+alt-down = 'focus-monitor down'
+
+# モニター間ウィンドウ移動 (alt + shift + 方向キー)
+alt-shift-left = 'move-node-to-monitor left'
+alt-shift-right = 'move-node-to-monitor right'
+alt-shift-up = 'move-node-to-monitor up'
+alt-shift-down = 'move-node-to-monitor down'
+
 # レイアウト切り替え
 alt-shift-t = 'layout tiling'
 alt-shift-f = 'layout floating'


### PR DESCRIPTION
## 影響範囲
AeroSpaceのキーボードショートカット設定

## 変更概要
- alt+方向キーでモニター間フォーカス移動を追加
- alt+shift+方向キーでモニター間ウィンドウ移動を追加

## AIが確認したこと
- [x] 設定ファイルの構文が正しいこと
- [x] `aerospace reload-config` でエラーなく反映されること

## 人間に確認してほしいこと
- [ ] 外部モニター接続時に alt+左右 でフォーカスが移動すること
- [ ] 外部モニター接続時に alt+shift+左右 でウィンドウが移動すること