### PR TITLE
feat: kccコマンドを追加

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -127,6 +127,10 @@ function ccc() {
     fi
 }
 
+function kcc() {
+    cd "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/kagemusha" && cc
+}
+
 # -------------------------------------
 # キーバインド
 # -------------------------------------


### PR DESCRIPTION
## 影響範囲
zshrcに新しいコマンド `kcc` が追加される

## 変更概要
- `kcc` コマンドを追加: kagemusha（Obsidian vault）ディレクトリに移動してClaude Codeを起動するショートカット

## AIが確認したこと
- [x] 既存の `ccc` 関数と同様のパターンで実装
- [x] `cc` エイリアスを再利用

## 人間に確認してほしいこと
- [ ] `source ~/.zshrc` で反映後、`kcc` コマンドが期待通り動作すること