### PR TITLE
chore: .PHONYからlink/claudeを削除

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PWD := $(shell pwd)
 
-.PHONY: link unlink link/home link/config link/claude copy/claude setup package/install package/cleanup package/check package/dump yazi/install npm/install
+.PHONY: link unlink link/home link/config copy/claude setup package/install package/cleanup package/check package/dump yazi/install npm/install
 
 link: link/home link/config copy/claude
 


### PR DESCRIPTION
## Impact
Makefileの.PHONYターゲット宣言の整理のみ。動作への影響なし。

## Changes
- `.PHONY`から不要な`link/claude`を削除（`copy/claude`へのリネーム済みのため）

## AI verified
- [x] link/claudeターゲットが既にcopy/claudeにリネーム済みであることを確認
- [x] .PHONYの他のターゲットに影響なし

## Human review needed
- [ ] 変更内容の確認