### PR TITLE
feat: mdviewスクリプト追加とzshrc整理

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -110,8 +110,7 @@ function peco_select_history() {
 zle -N peco_select_history
 
 function peco_src() {
-    # ghq listにkagemushaを追加（iCloud上のObsidian vault）
-    local src_dir=$( (ghq list --full-path; echo "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/kuromaku") | peco --query "$LBUFFER")
+    local src_dir=$(ghq list --full-path | peco --query "$LBUFFER")
     if [ -n "$src_dir" ]; then
         BUFFER="cd \"$src_dir\""
         zle accept-line
@@ -121,7 +120,7 @@ function peco_src() {
 zle -N peco_src
 
 function ccc() {
-    local src_dir=$( (ghq list --full-path; echo "$HOME/Library/Mobile Documents/iCloud~md~obsidian/Documents/kuromaku") | peco --query "$LBUFFER")
+    local src_dir=$(ghq list --full-path | peco --query "$LBUFFER")
     if [ -n "$src_dir" ]; then
         cd "$src_dir" && claude --dangerously-skip-permissions
     fi


### PR DESCRIPTION
## Impact
yaziのファイルブラウジング体験を強化。Mermaid図を含むMarkdownファイルをTUI上でプレビュー可能にする。

## Changes
- `bin/mdview`: Mermaid図付きMarkdownをTUIプレビューするスクリプトを追加（glow + mmdc連携）
- `yazi/keymap.toml`: yaziからmdviewを呼び出すキーバインド（`M`キー）を追加
- `Brewfile`: glow（Markdown CLIレンダラ）を追加
- `Makefile`: `bin/mdview`のシンボリックリンク作成を追加
- `zsh/zshrc`: `peco_src`と`ccc`からObsidian vault直接パス参照を削除し簡素化

## AI verified
- [x] mdviewスクリプトの構文チェック
- [x] zshrc変更が既存機能を壊さないことを確認

## Human review needed
- [ ] mdviewの動作確認（glow, mmdc が正しくインストールされているか）
- [ ] yaziのキーバインド（`M`キー）が他と競合しないか確認