### PR TITLE
Point Ctrl-Y shortcut at Cursor

### DIFF
--- a/bettertouchtool/default.bttpreset
+++ b/bettertouchtool/default.bttpreset
@@ -343,7 +343,7 @@
               "BTTUUID" : "9C9AEF82-527F-4322-B12E-1A6262B79049",
               "BTTPredefinedActionType" : 49,
               "BTTPredefinedActionName" : "アプリケーションを起動  or  ファイルを開く  or  AppleScriptを開始…",
-              "BTTLaunchPath" : "/Applications/Antigravity.app",
+              "BTTLaunchPath" : "/Applications/Cursor.app",
               "BTTOrder" : 8
             }
           ]


### PR DESCRIPTION
## Impact
Updates the BetterTouchTool preset so Ctrl+Y opens Cursor instead of AntiGravity.

## Changes
- Change the Ctrl+Y launch path from `/Applications/Antigravity.app` to `/Applications/Cursor.app`

## AI verified
- [x] Confirmed preset JSON parses with `jq empty`
- [x] Confirmed live BetterTouchTool DB now maps Ctrl+Y to `/Applications/Cursor.app`

## Human review needed
- [ ] Confirm Ctrl+Y opens Cursor on the local machine
