### PR TITLE
[WIP] rename Codex workspace

### DIFF
--- a/codex/config.toml
+++ b/codex/config.toml
@@ -28,8 +28,8 @@ fast_mode = true
 persistence = "save-all"
 
 [tui]
-# Claude Code の statusline と同じ並び: ディレクトリ > ブランチ > モデル+reasoning > ctx使用率
-status_line = ["current-dir", "git-branch", "model-with-reasoning", "context-used"]
+# Claude Code の statusline と同じ並び: プロジェクト名 > ブランチ > モデル+reasoning > ctx使用率
+status_line = ["project-name", "git-branch", "model-with-reasoning", "context-used"]
 notifications = ["agent-turn-complete","approval-requested"]
 
 [tui.model_availability_nux]


### PR DESCRIPTION
## 目的
Codex の statusline でリポジトリパスではなくプロジェクト名を表示する。

## 完了条件
- [x] macbook-provisioning の表示名が期待する値になっている

## 進捗メモ
- 2026-07-06: 開始
- 2026-07-06: status_line を project-name に変更し、strict config で読み込み確認済み
