### PR TITLE
tmux使用量表示の視認性改善（絵文字ラベル・ツール色分け・数字強調）

### DIFF
--- a/bin/tmux-usage.sh
+++ b/bin/tmux-usage.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Claude Code / Codex の「使用量（レート上限に対する％）」を tmux ステータス用に1行で出力する。
-#   ✳[account 5h:NN% 週:NN% 枠:NN%]   Claude Code(✳): アカウント(@前のみ) / 5時間枠 / 週(全体) / 週(スコープ上限)
-#   ⬢[5h:NN% 週:NN%]                  Codex(⬢): 5時間枠 / 週
-# ％はしきい値で色分けする（〜49%緑 / 50〜79%黄 / 80%〜赤・太字）。tmuxの #[] スタイルを直接出力する。
+#   ✳[account ⏳NN% 📅NN% 🎯NN%]   Claude Code(✳ 橙): アカウント(@前のみ) / ⏳5時間枠 / 📅週(全体) / 🎯週(スコープ上限)
+#   ⬢[⏳NN% 📅NN%]                 Codex(⬢ 青): ⏳5時間枠 / 📅週
+# ％は常に太字＋しきい値で色分け（〜49%緑 / 50〜79%黄 / 80%〜赤）。記号と[]はツール色で塗り分ける。
+# tmuxの #[] スタイルを直接出力する。
 #
 # データ源:
 #   Claude … OAuth usage API (api.anthropic.com/api/oauth/usage) が各上限の percent を返す
@@ -64,14 +65,13 @@ refresh() {
         def p(k): ([.limits[]? | select(.kind==k) | .percent] | first);
         def f(v): if v==null then "#[fg=#6c7086]-"
           else ((v|round) as $n |
-            (if $n>=80 then "#[fg=#f38ba8,bold]" elif $n>=50 then "#[fg=#f9e2af]" else "#[fg=#a6e3a1]" end)
+            (if $n>=80 then "#[fg=#f38ba8,bold]" elif $n>=50 then "#[fg=#f9e2af,bold]" else "#[fg=#a6e3a1,bold]" end)
             + ($n|tostring) + "%#[nobold]") end;
-        def l(k): "#[fg=#6c7086]" + k + ":";
         (p("session")     // .five_hour.utilization) as $s |
         (p("weekly_all")  // .seven_day.utilization) as $w |
         p("weekly_scoped") as $g |
         if ($s == null and $w == null and $g == null) then empty else
-          "✳[\(l("5h"))\(f($s)) \(l("週"))\(f($w)) \(l("枠"))\(f($g))#[fg=#a6e3a1]]"
+          "✳[⏳\(f($s)) 📅\(f($w)) 🎯\(f($g))#[fg=#fab387]]"
         end
       end
     ' 2>/dev/null)
@@ -79,7 +79,8 @@ refresh() {
   if [ -n "$cc" ]; then
     # メールは@より前だけ表示して行を短くする（アカウント判別には十分）
     [ -n "$cc_email" ] && cc="✳[${cc_email%%@*} ${cc#✳[}"
-    printf '%s' "$cc" > "$CACHE_CC"
+    # 記号・[]・アカウント名をClaude色（橙）で塗る
+    printf '%s' "#[fg=#fab387]$cc" > "$CACHE_CC"
   fi
 
   # --- Codex ---（複数セッションから最も新しい rate_limits を採用）
@@ -92,10 +93,9 @@ refresh() {
       .payload.rate_limits as $r |
       def f(v): if v==null then "#[fg=#6c7086]-"
         else ((v|round) as $n |
-          (if $n>=80 then "#[fg=#f38ba8,bold]" elif $n>=50 then "#[fg=#f9e2af]" else "#[fg=#a6e3a1]" end)
+          (if $n>=80 then "#[fg=#f38ba8,bold]" elif $n>=50 then "#[fg=#f9e2af,bold]" else "#[fg=#a6e3a1,bold]" end)
           + ($n|tostring) + "%#[nobold]") end;
-      def l(k): "#[fg=#6c7086]" + k + ":";
-      "⬢[\(l("5h"))\(f($r.primary.used_percent)) \(l("週"))\(f($r.secondary.used_percent))#[fg=#a6e3a1]]"
+      "#[fg=#89b4fa]⬢[⏳\(f($r.primary.used_percent)) 📅\(f($r.secondary.used_percent))#[fg=#89b4fa]]"
     ' 2>/dev/null)
     [ -n "$cx" ] && printf '%s' "$cx" > "$CACHE_CX"
   fi

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -44,7 +44,8 @@ bind -n MouseDown1Status select-window -t =
 
 # 下側: Claude Code / Codex のアカウント・使用量 + active pane の実行コマンド
 set -g pane-border-status bottom
-set -g pane-border-format " #{?pane_active,#[fg=#a6e3a1]#(~/ghq/github.com/lifehackniki/macbook-provisioning/bin/tmux-usage.sh) #[fg=#6c7086]| ,}#[bold]#{pane_current_command}#[nobold] "
+# 使用量表示の色はスクリプト側で塗る（Claude橙/Codex青）ため、ここでは準備中表示用のグレーだけ指定
+set -g pane-border-format " #{?pane_active,#[fg=#6c7086]#(~/ghq/github.com/lifehackniki/macbook-provisioning/bin/tmux-usage.sh) #[fg=#6c7086]| ,}#[bold]#{pane_current_command}#[nobold] "
 set -g pane-border-style "fg=#45475a"
 set -g pane-active-border-style "fg=#f9e2af,bold"
 # アクティブなペインを目立たせる: ボーダーを太い二重線に、非アクティブペインは暗く沈める


### PR DESCRIPTION
## ユーザー価値
tmux下枠の使用量表示で、どちらのツールがどれだけ枠を使っているかがひと目で分かるようになった。

## 影響範囲
tmuxペイン下枠の使用量表示の見た目のみ。取得ロジック・更新頻度・キャッシュ構造は変わらない。

## 変更内容
- ラベルを絵文字に変更: `5h:`→⏳、`週:`→📅、`枠:`→🎯
- ツールごとに色分け: Claude（✳・アカウント名・[ ]）は橙 `#fab387`、Codex（⬢・[ ]）は青 `#89b4fa`
- 数字（％）を常に太字にして強調（しきい値の色分け 緑/黄/赤 は従来どおり）
- tmux.conf側の使用量表示の先頭色を緑→グレーに（色はスクリプト側で塗るため。準備中の `usage…` 表示のみグレー）

## 確認方法
- ブランチのスクリプトを直接実行すると新フォーマットが出る:
  `bash .worktrees/tmux-usage-emoji-colors/bin/tmux-usage.sh`（キャッシュ経由なので数秒後に再実行）
- 実出力例（実データで検証済み）:
  `#[fg=#fab387]✳[account ⏳#[fg=#a6e3a1,bold]6%#[nobold] 📅…19%… 🎯…19%…] #[fg=#89b4fa]⬢[⏳6% 📅-]`
- マージ後は `tmux` 内で Ctrl+b→r で反映（bin/はシンボリックリンク運用のためリンク作業不要）

## 完了条件
- [x] 「5h:」「週:」「枠:」のテキストラベルが絵文字（⏳📅🎯）になっている
- [x] Claude（✳橙）とCodex（⬢青）が色で見分けられる
- [x] 数字（％）が太字でラベルより目立つ
