### PR TITLE
tmux使用量表示: 枠を白に、数字だけClaude橙/Codex青に

### DIFF
--- a/bin/tmux-usage.sh
+++ b/bin/tmux-usage.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Claude Code / Codex の「使用量（レート上限に対する％）」を tmux ステータス用に1行で出力する。
-#   ✳[account ⏳NN% 📅NN% 🎯NN%]   Claude Code(✳ 橙): アカウント(@前のみ) / ⏳5時間枠 / 📅週(全体) / 🎯週(スコープ上限)
-#   ⬢[⏳NN% 📅NN%]                 Codex(⬢ 青): ⏳5時間枠 / 📅週
-# ％は常に太字＋しきい値で色分け（〜49%緑 / 50〜79%黄 / 80%〜赤）。記号と[]はツール色で塗り分ける。
-# tmuxの #[] スタイルを直接出力する。
+#   ✳[account ⏳NN% 📅NN% 🎯NN%]   Claude Code(✳): アカウント(@前のみ) / ⏳5時間枠 / 📅週(全体) / 🎯週(スコープ上限)
+#   ⬢[⏳NN% 📅NN%]                 Codex(⬢): ⏳5時間枠 / 📅週
+# 記号・[]・アカウント名は白。％数字だけをツール色（Claude橙 / Codex青）＋太字にして、
+# 数字の色でどちらのツールかが分かるようにする。tmuxの #[] スタイルを直接出力する。
 #
 # データ源:
 #   Claude … OAuth usage API (api.anthropic.com/api/oauth/usage) が各上限の percent を返す
@@ -63,15 +63,14 @@ refresh() {
     cc=$(printf '%s' "$j" | jq -r '
       if (.error != null) then empty else
         def p(k): ([.limits[]? | select(.kind==k) | .percent] | first);
-        def f(v): if v==null then "#[fg=#6c7086]-"
+        def f(v): if v==null then "#[fg=#6c7086]-#[fg=#cdd6f4]"
           else ((v|round) as $n |
-            (if $n>=80 then "#[fg=#f38ba8,bold]" elif $n>=50 then "#[fg=#f9e2af,bold]" else "#[fg=#a6e3a1,bold]" end)
-            + ($n|tostring) + "%#[nobold]") end;
+            "#[fg=#fab387,bold]" + ($n|tostring) + "%#[fg=#cdd6f4,nobold]") end;
         (p("session")     // .five_hour.utilization) as $s |
         (p("weekly_all")  // .seven_day.utilization) as $w |
         p("weekly_scoped") as $g |
         if ($s == null and $w == null and $g == null) then empty else
-          "✳[⏳\(f($s)) 📅\(f($w)) 🎯\(f($g))#[fg=#fab387]]"
+          "✳[⏳\(f($s)) 📅\(f($w)) 🎯\(f($g))]"
         end
       end
     ' 2>/dev/null)
@@ -79,8 +78,8 @@ refresh() {
   if [ -n "$cc" ]; then
     # メールは@より前だけ表示して行を短くする（アカウント判別には十分）
     [ -n "$cc_email" ] && cc="✳[${cc_email%%@*} ${cc#✳[}"
-    # 記号・[]・アカウント名をClaude色（橙）で塗る
-    printf '%s' "#[fg=#fab387]$cc" > "$CACHE_CC"
+    # 記号・[]・アカウント名は白。ツールの区別は％数字の色（橙）で付く
+    printf '%s' "#[fg=#cdd6f4]$cc" > "$CACHE_CC"
   fi
 
   # --- Codex ---（複数セッションから最も新しい rate_limits を採用）
@@ -91,11 +90,10 @@ refresh() {
   if [ -n "$line" ] && [ "$line" != "null" ]; then
     cx=$(printf '%s' "$line" | jq -r '
       .payload.rate_limits as $r |
-      def f(v): if v==null then "#[fg=#6c7086]-"
+      def f(v): if v==null then "#[fg=#6c7086]-#[fg=#cdd6f4]"
         else ((v|round) as $n |
-          (if $n>=80 then "#[fg=#f38ba8,bold]" elif $n>=50 then "#[fg=#f9e2af,bold]" else "#[fg=#a6e3a1,bold]" end)
-          + ($n|tostring) + "%#[nobold]") end;
-      "#[fg=#89b4fa]⬢[⏳\(f($r.primary.used_percent)) 📅\(f($r.secondary.used_percent))#[fg=#89b4fa]]"
+          "#[fg=#89b4fa,bold]" + ($n|tostring) + "%#[fg=#cdd6f4,nobold]") end;
+      "#[fg=#cdd6f4]⬢[⏳\(f($r.primary.used_percent)) 📅\(f($r.secondary.used_percent))]"
     ' 2>/dev/null)
     [ -n "$cx" ] && printf '%s' "$cx" > "$CACHE_CX"
   fi

--- a/bin/tmux-usage.sh
+++ b/bin/tmux-usage.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Claude Code / Codex の「使用量（レート上限に対する％）」を tmux ステータス用に1行で出力する。
 #   🟠[⏳NN% 📅NN% 🎯NN% account]   Claude Code(🟠): ⏳5時間枠 / 📅週(全体) / 🎯週(スコープ上限) / アカウント(@前のみ)
-#   🔵[⏳NN% 📅NN% account]         Codex(🔵): ⏳5時間枠 / 📅週 / アカウント(@前のみ)
+#   🔵[⏳NN% 📅NN%]                 Codex(🔵): ⏳5時間枠 / 📅週（1アカウント運用のためアカウント表示なし）
 # 記号は文字に見えない色付き絵文字（数字色と対応）。[]・アカウント名は白。
 # ％数字だけをツール色（Claude橙 / Codex青）＋太字にして、数字の色でどちらのツールかが分かるようにする。
 # tmuxの #[] スタイルを直接出力する。
@@ -34,16 +34,6 @@ claude_email() {
   email=$(CMUX_CLAUDE_HOOKS_DISABLED=1 "$cmd" auth status 2>/dev/null | jq -r '.email // empty' 2>/dev/null)
   [ -n "$email" ] && printf '%s\n' "$email"
 }
-
-# Codex のアカウント識別子: ~/.codex/auth.json の id_token(JWT) の email クレームから取る
-codex_email() {
-  local p
-  p=$(jq -r '.tokens.id_token // empty' ~/.codex/auth.json 2>/dev/null | cut -d. -f2 | tr '_-' '/+')
-  [ -z "$p" ] && return 0
-  case $(( ${#p} % 4 )) in 2) p="${p}==" ;; 3) p="${p}=" ;; esac
-  printf '%s' "$p" | base64 -D 2>/dev/null | jq -r '.email // empty' 2>/dev/null
-}
-
 refresh() {
   # 二重起動防止（mkdirはアトミック）。古いロックは異常終了の残骸として破棄する。
   if ! mkdir "$LOCK" 2>/dev/null; then
@@ -92,8 +82,7 @@ refresh() {
   fi
 
   # --- Codex ---（複数セッションから最も新しい rate_limits を採用）
-  local cx="" cx_email line
-  cx_email=$(codex_email)
+  local cx="" line
   line=$(for fp in $(ls -t ~/.codex/sessions/*/*/*/*.jsonl 2>/dev/null | head -12); do
            grep -h "rate_limits" "$fp" 2>/dev/null | tail -1
          done | jq -s 'map(select(.payload.rate_limits)) | sort_by(.timestamp) | last' 2>/dev/null)
@@ -105,7 +94,7 @@ refresh() {
           "#[fg=#89b4fa,bold]" + ($n|tostring) + "%#[fg=#cdd6f4,nobold]") end;
       "⏳\(f($r.primary.used_percent)) 📅\(f($r.secondary.used_percent))"
     ' 2>/dev/null)
-    [ -n "$cx" ] && printf '%s' "#[fg=#cdd6f4]🔵[${cx}${cx_email:+ ${cx_email%%@*}}]" > "$CACHE_CX"
+    [ -n "$cx" ] && printf '%s' "#[fg=#cdd6f4]🔵[${cx}]" > "$CACHE_CX"
   fi
 
   # 表示行は「今ある分」を組み立てる（片方の取得に失敗しても、もう片方は前回値で残る）

--- a/bin/tmux-usage.sh
+++ b/bin/tmux-usage.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Claude Code / Codex の「使用量（レート上限に対する％）」を tmux ステータス用に1行で出力する。
-#   ✳[account ⏳NN% 📅NN% 🎯NN%]   Claude Code(✳): アカウント(@前のみ) / ⏳5時間枠 / 📅週(全体) / 🎯週(スコープ上限)
-#   ⬢[⏳NN% 📅NN%]                 Codex(⬢): ⏳5時間枠 / 📅週
-# 記号・[]・アカウント名は白。％数字だけをツール色（Claude橙 / Codex青）＋太字にして、
-# 数字の色でどちらのツールかが分かるようにする。tmuxの #[] スタイルを直接出力する。
+#   🟠[⏳NN% 📅NN% 🎯NN% account]   Claude Code(🟠): ⏳5時間枠 / 📅週(全体) / 🎯週(スコープ上限) / アカウント(@前のみ)
+#   🔵[⏳NN% 📅NN% account]         Codex(🔵): ⏳5時間枠 / 📅週 / アカウント(@前のみ)
+# 記号は文字に見えない色付き絵文字（数字色と対応）。[]・アカウント名は白。
+# ％数字だけをツール色（Claude橙 / Codex青）＋太字にして、数字の色でどちらのツールかが分かるようにする。
+# tmuxの #[] スタイルを直接出力する。
 #
 # データ源:
 #   Claude … OAuth usage API (api.anthropic.com/api/oauth/usage) が各上限の percent を返す
@@ -32,6 +33,15 @@ claude_email() {
   cmd=$(claude_bin) || return 0
   email=$(CMUX_CLAUDE_HOOKS_DISABLED=1 "$cmd" auth status 2>/dev/null | jq -r '.email // empty' 2>/dev/null)
   [ -n "$email" ] && printf '%s\n' "$email"
+}
+
+# Codex のアカウント識別子: ~/.codex/auth.json の id_token(JWT) の email クレームから取る
+codex_email() {
+  local p
+  p=$(jq -r '.tokens.id_token // empty' ~/.codex/auth.json 2>/dev/null | cut -d. -f2 | tr '_-' '/+')
+  [ -z "$p" ] && return 0
+  case $(( ${#p} % 4 )) in 2) p="${p}==" ;; 3) p="${p}=" ;; esac
+  printf '%s' "$p" | base64 -D 2>/dev/null | jq -r '.email // empty' 2>/dev/null
 }
 
 refresh() {
@@ -70,20 +80,20 @@ refresh() {
         (p("weekly_all")  // .seven_day.utilization) as $w |
         p("weekly_scoped") as $g |
         if ($s == null and $w == null and $g == null) then empty else
-          "✳[⏳\(f($s)) 📅\(f($w)) 🎯\(f($g))]"
+          "⏳\(f($s)) 📅\(f($w)) 🎯\(f($g))"
         end
       end
     ' 2>/dev/null)
   fi
   if [ -n "$cc" ]; then
-    # メールは@より前だけ表示して行を短くする（アカウント判別には十分）
-    [ -n "$cc_email" ] && cc="✳[${cc_email%%@*} ${cc#✳[}"
+    # メールは@より前だけ末尾に表示して行を短くする（アカウント判別には十分）
     # 記号・[]・アカウント名は白。ツールの区別は％数字の色（橙）で付く
-    printf '%s' "#[fg=#cdd6f4]$cc" > "$CACHE_CC"
+    printf '%s' "#[fg=#cdd6f4]🟠[${cc}${cc_email:+ ${cc_email%%@*}}]" > "$CACHE_CC"
   fi
 
   # --- Codex ---（複数セッションから最も新しい rate_limits を採用）
-  local cx="" line
+  local cx="" cx_email line
+  cx_email=$(codex_email)
   line=$(for fp in $(ls -t ~/.codex/sessions/*/*/*/*.jsonl 2>/dev/null | head -12); do
            grep -h "rate_limits" "$fp" 2>/dev/null | tail -1
          done | jq -s 'map(select(.payload.rate_limits)) | sort_by(.timestamp) | last' 2>/dev/null)
@@ -93,9 +103,9 @@ refresh() {
       def f(v): if v==null then "#[fg=#6c7086]-#[fg=#cdd6f4]"
         else ((v|round) as $n |
           "#[fg=#89b4fa,bold]" + ($n|tostring) + "%#[fg=#cdd6f4,nobold]") end;
-      "#[fg=#cdd6f4]⬢[⏳\(f($r.primary.used_percent)) 📅\(f($r.secondary.used_percent))]"
+      "⏳\(f($r.primary.used_percent)) 📅\(f($r.secondary.used_percent))"
     ' 2>/dev/null)
-    [ -n "$cx" ] && printf '%s' "$cx" > "$CACHE_CX"
+    [ -n "$cx" ] && printf '%s' "#[fg=#cdd6f4]🔵[${cx}${cx_email:+ ${cx_email%%@*}}]" > "$CACHE_CX"
   fi
 
   # 表示行は「今ある分」を組み立てる（片方の取得に失敗しても、もう片方は前回値で残る）


### PR DESCRIPTION
## ユーザー価値
tmux下枠の使用量表示が、色付き絵文字（🟠Claude/🔵Codex）と数字のツール色でぱっと見で判別でき、Codexもどのアカウントか分かるようになった。

## 影響範囲
tmuxペイン下枠の使用量表示のみ（bin/tmux-usage.sh単体）。しきい値の緑/黄/赤の色分けは数字のツール色と両立しないため廃止。

## 変更内容
- 枠・[ ]・アカウント名を白（#cdd6f4）に、％数字だけ太字のツール色（Claude橙 #fab387 / Codex青 #89b4fa）に
- 記号 ✳/⬢ は文字に見えるため、数字色と対応する色付き絵文字 🟠/🔵 に変更
- アカウント名（メール@前のみ）を行末に移動
- Codexのアカウント表示は一度追加後、サニワ指示（1アカウント運用のため不要）で削除

## 確認方法
- `bash bin/tmux-usage.sh`（ブランチ内で実行、キャッシュTTL60秒）
- 実出力例（実データで検証済み）: `🟠[⏳9% 📅20% 🎯20% account]  🔵[⏳6% 📅-]`
- マージ後はtmuxの次回更新（60秒以内）で自動反映

## 完了条件
- [x] 記号が文字に見えない色付き絵文字（🟠🔵）で、数字色と対応している
- [x] [ ]・アカウント名が白、％数字だけClaude橙/Codex青の太字
- [x] Claudeのアカウント名が末尾（Codexはサニワ指示によりアカウント表示なし）
